### PR TITLE
Support for transparent pixels

### DIFF
--- a/dpypx/autodraw.py
+++ b/dpypx/autodraw.py
@@ -31,7 +31,10 @@ class AutoDrawer:
         resized = image.resize((width, height), Image.LANCZOS)
         data = list(resized.getdata())
         grid = [
-            [(Pixel(*pixel[:3]), pixel[3] > 127) for pixel in data[start:start + width]]
+            [
+                (Pixel(*pixel[:3]), pixel[3] > 127)
+                for pixel in data[start:start + width]
+            ]
             for start in range(0, len(data), width)
         ]
         return cls(client, *xy, grid)

--- a/dpypx/autodraw.py
+++ b/dpypx/autodraw.py
@@ -55,7 +55,7 @@ class AutoDrawer:
         for _ in range(height):
             row = []
             for _ in range(width):
-                row.append((Pixel.from_hex(lines.pop(0))), True)
+                row.append((Pixel.from_hex(lines.pop(0)), True))
             grid.append(row)
         return cls(client, x, y, grid)
 
@@ -97,7 +97,7 @@ class AutoDrawer:
         Returns True if the pixel was not already drawn.
         """
         colour, opaque = self.grid[y - self.y0][x - self.x0]
-	    if not opaque:
+	if not opaque:
             logger.debug(f"Skipping transparent pixel at {x}, {y}.")
             return False
         if self.canvas and self.canvas[x, y] == colour:


### PR DESCRIPTION
### Description
Transparent pixels in the image will not be drawn. Semi transparent pixels will be rounded to either fully transparent or opaque, because I wasn't exactly sure what to do with semi transparent pixels. I could technically draw a semi transparent pixel by looking at the previous pixel, but that would make draw_and_fix go forever since there isn't really a clear stop condition.

### Implementation
The grid in AutoDrawer used be a 2D array of Pixels. I modified it to be an 2D array of tuples, each tuple containing a pixel and a boolean value. The boolean determines if the pixel is transparent or not i.e. if it's going to be drawn. 

### Test
I tested it with a few .pngs at scale=1 and it seems to work fine